### PR TITLE
Add Snowflake, Databricks and Iceberg cloud data connectors

### DIFF
--- a/server-api/connectors/cloud-data/README.md
+++ b/server-api/connectors/cloud-data/README.md
@@ -1,0 +1,101 @@
+# NexaMap Cloud Data Connectors
+
+This module provides dependency-free Node.js connectors for Snowflake, Databricks SQL Warehouses, and Apache Iceberg REST catalogs. The connectors use the built-in `fetch` API available in Node.js 18 and later.
+
+Credentials must stay in the server process. Do not expose access tokens to the browser or commit them to source control.
+
+## Factory
+
+```js
+const { createCloudDataConnector } = require('./connectors/cloud-data');
+```
+
+## Snowflake
+
+The Snowflake connector uses the Snowflake SQL API.
+
+```js
+const snowflake = createCloudDataConnector('snowflake', {
+  accountUrl: process.env.SNOWFLAKE_ACCOUNT_URL,
+  token: process.env.SNOWFLAKE_TOKEN,
+  tokenType: 'KEYPAIR_JWT', // or OAUTH
+  warehouse: process.env.SNOWFLAKE_WAREHOUSE,
+  database: process.env.SNOWFLAKE_DATABASE,
+  schema: process.env.SNOWFLAKE_SCHEMA,
+  role: process.env.SNOWFLAKE_ROLE,
+});
+
+const result = await snowflake.execute('SELECT * FROM LOCATIONS LIMIT 100');
+const geojson = await snowflake.queryGeoJSON(
+  'SELECT ID, NAME, LONGITUDE, LATITUDE FROM LOCATIONS LIMIT 100',
+  { idColumn: 'ID', longitudeColumn: 'LONGITUDE', latitudeColumn: 'LATITUDE' },
+);
+```
+
+The token can be an OAuth access token or a key-pair JWT, depending on `tokenType`.
+
+## Databricks
+
+The Databricks connector uses the Statement Execution API for a SQL warehouse.
+
+```js
+const databricks = createCloudDataConnector('databricks', {
+  host: process.env.DATABRICKS_HOST,
+  token: process.env.DATABRICKS_TOKEN,
+  warehouseId: process.env.DATABRICKS_WAREHOUSE_ID,
+  catalog: process.env.DATABRICKS_CATALOG,
+  schema: process.env.DATABRICKS_SCHEMA,
+});
+
+const result = await databricks.execute('SELECT * FROM spatial.locations LIMIT 100');
+const geojson = await databricks.queryGeoJSON(
+  'SELECT id, name, longitude, latitude FROM spatial.locations LIMIT 100',
+  { idColumn: 'id' },
+);
+```
+
+## Apache Iceberg
+
+The Iceberg connector implements catalog discovery through the Iceberg REST Catalog API.
+
+```js
+const iceberg = createCloudDataConnector('iceberg', {
+  baseUrl: process.env.ICEBERG_CATALOG_URL,
+  prefix: process.env.ICEBERG_CATALOG_PREFIX,
+  token: process.env.ICEBERG_CATALOG_TOKEN,
+});
+
+const namespaces = await iceberg.listNamespaces();
+const tables = await iceberg.listTables(['analytics', 'spatial']);
+const table = await iceberg.tableMetadata(['analytics', 'spatial'], 'locations');
+```
+
+The REST catalog returns table metadata and metadata locations. Reading Parquet data files is intentionally left to a query engine such as Snowflake, Databricks, Trino, DuckDB, or Spark.
+
+## GeoJSON conversion
+
+`queryGeoJSON()` supports:
+
+- GeoJSON geometry objects or JSON strings through `geometryColumn`
+- Longitude and latitude columns through `longitudeColumn` and `latitudeColumn`
+- Optional feature IDs through `idColumn`
+- Automatic FeatureCollection bounding-box calculation
+
+Example:
+
+```js
+const geojson = await connector.queryGeoJSON(sql, {
+  geometryColumn: 'geometry',
+  longitudeColumn: 'longitude',
+  latitudeColumn: 'latitude',
+  idColumn: 'id',
+});
+```
+
+## Run tests
+
+From the repository root:
+
+```bash
+npm test
+```

--- a/server-api/connectors/cloud-data/base-connector.js
+++ b/server-api/connectors/cloud-data/base-connector.js
@@ -1,0 +1,108 @@
+'use strict';
+
+function assertNonEmpty(value, name) {
+  if (value == null || String(value).trim() === '') {
+    throw new Error(`${name} is required.`);
+  }
+  return String(value).trim();
+}
+
+function normalizeBaseUrl(value, name = 'baseUrl') {
+  return assertNonEmpty(value, name).replace(/\/+$/, '');
+}
+
+async function readJsonResponse(response, context) {
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (_err) {
+    payload = null;
+  }
+  if (!response.ok) {
+    const message = payload && (payload.message || payload.error || payload.error_message)
+      ? (payload.message || payload.error || payload.error_message)
+      : `${context} failed with status ${response.status}`;
+    throw new Error(String(message));
+  }
+  return payload;
+}
+
+function quoteIdentifier(identifier) {
+  const value = assertNonEmpty(identifier, 'identifier');
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function flattenCoordinates(input, output = []) {
+  if (!Array.isArray(input)) return output;
+  if (input.length >= 2 && Number.isFinite(input[0]) && Number.isFinite(input[1])) {
+    output.push([Number(input[0]), Number(input[1])]);
+    return output;
+  }
+  input.forEach((value) => flattenCoordinates(value, output));
+  return output;
+}
+
+function computeBoundingBox(features) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  (features || []).forEach((feature) => {
+    const coordinates = feature && feature.geometry ? feature.geometry.coordinates : null;
+    flattenCoordinates(coordinates).forEach(([x, y]) => {
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    });
+  });
+  return Number.isFinite(minX) ? [minX, minY, maxX, maxY] : null;
+}
+
+function rowsToGeoJSON(rows, options = {}) {
+  const geometryColumn = options.geometryColumn || 'geometry';
+  const longitudeColumn = options.longitudeColumn || 'longitude';
+  const latitudeColumn = options.latitudeColumn || 'latitude';
+  const idColumn = options.idColumn || null;
+
+  const features = (rows || []).map((row, index) => {
+    let geometry = null;
+    const rawGeometry = row ? row[geometryColumn] : null;
+    if (rawGeometry && typeof rawGeometry === 'object') {
+      geometry = rawGeometry.type === 'Feature' ? rawGeometry.geometry : rawGeometry;
+    } else if (typeof rawGeometry === 'string') {
+      try {
+        const parsed = JSON.parse(rawGeometry);
+        geometry = parsed.type === 'Feature' ? parsed.geometry : parsed;
+      } catch (_err) {
+        geometry = null;
+      }
+    }
+    if (!geometry && row && Number.isFinite(Number(row[longitudeColumn])) && Number.isFinite(Number(row[latitudeColumn]))) {
+      geometry = { type: 'Point', coordinates: [Number(row[longitudeColumn]), Number(row[latitudeColumn])] };
+    }
+    const properties = { ...(row || {}) };
+    delete properties[geometryColumn];
+    return {
+      type: 'Feature',
+      id: idColumn && row && row[idColumn] != null ? row[idColumn] : index,
+      geometry,
+      properties,
+    };
+  }).filter((feature) => feature.geometry);
+
+  return {
+    type: 'FeatureCollection',
+    bbox: computeBoundingBox(features),
+    features,
+  };
+}
+
+module.exports = {
+  assertNonEmpty,
+  normalizeBaseUrl,
+  readJsonResponse,
+  quoteIdentifier,
+  rowsToGeoJSON,
+  computeBoundingBox,
+};

--- a/server-api/connectors/cloud-data/databricks-connector.js
+++ b/server-api/connectors/cloud-data/databricks-connector.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const {
+  assertNonEmpty,
+  normalizeBaseUrl,
+  readJsonResponse,
+  rowsToGeoJSON,
+} = require('./base-connector');
+
+class DatabricksConnector {
+  constructor(config = {}) {
+    this.host = normalizeBaseUrl(config.host, 'host');
+    this.token = assertNonEmpty(config.token, 'token');
+    this.warehouseId = assertNonEmpty(config.warehouseId, 'warehouseId');
+    this.catalog = config.catalog || null;
+    this.schema = config.schema || null;
+  }
+
+  headers() {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+  }
+
+  async execute(sql, options = {}) {
+    const response = await fetch(`${this.host}/api/2.0/sql/statements`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        statement: assertNonEmpty(sql, 'sql'),
+        warehouse_id: this.warehouseId,
+        catalog: options.catalog || this.catalog || undefined,
+        schema: options.schema || this.schema || undefined,
+        wait_timeout: options.waitTimeout || '10s',
+        on_wait_timeout: 'CONTINUE',
+        disposition: 'INLINE',
+        format: 'JSON_ARRAY',
+      }),
+    });
+    const payload = await readJsonResponse(response, 'Databricks statement');
+    const state = payload.status && payload.status.state;
+    if (state && !['SUCCEEDED', 'FAILED', 'CANCELED', 'CLOSED'].includes(state)) {
+      return this.poll(payload.statement_id, options);
+    }
+    return this.normalizeResult(payload);
+  }
+
+  async poll(statementId, options = {}) {
+    const intervalMs = options.pollIntervalMs || 500;
+    const deadline = Date.now() + (options.timeoutSeconds || 60) * 1000;
+    while (Date.now() < deadline) {
+      const response = await fetch(`${this.host}/api/2.0/sql/statements/${encodeURIComponent(statementId)}`, {
+        headers: this.headers(),
+      });
+      const payload = await readJsonResponse(response, 'Databricks statement polling');
+      const state = payload.status && payload.status.state;
+      if (state === 'SUCCEEDED') return this.normalizeResult(payload);
+      if (['FAILED', 'CANCELED', 'CLOSED'].includes(state)) {
+        const message = payload.status && payload.status.error && payload.status.error.message;
+        throw new Error(message || `Databricks statement ended in state ${state}.`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    throw new Error('Databricks statement timed out.');
+  }
+
+  normalizeResult(payload = {}) {
+    const columns = (payload.manifest && payload.manifest.schema && payload.manifest.schema.columns) || [];
+    const names = columns.map((column) => column.name);
+    const values = (payload.result && payload.result.data_array) || [];
+    const rows = values.map((row) => Object.fromEntries(names.map((name, index) => [name, row[index]])));
+    return {
+      rows,
+      columns,
+      statementId: payload.statement_id || null,
+      rowCount: rows.length,
+    };
+  }
+
+  async listTables() {
+    const result = await this.execute('SHOW TABLES');
+    return result.rows;
+  }
+
+  async queryGeoJSON(sql, geoOptions = {}, executeOptions = {}) {
+    const result = await this.execute(sql, executeOptions);
+    return rowsToGeoJSON(result.rows, geoOptions);
+  }
+}
+
+module.exports = { DatabricksConnector };

--- a/server-api/connectors/cloud-data/example.js
+++ b/server-api/connectors/cloud-data/example.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { createCloudDataConnector } = require('./index');
+
+async function run() {
+  const provider = String(process.env.NEXAMAP_CLOUD_PROVIDER || '').toLowerCase();
+  let connector;
+
+  if (provider === 'snowflake') {
+    connector = createCloudDataConnector('snowflake', {
+      accountUrl: process.env.SNOWFLAKE_ACCOUNT_URL,
+      token: process.env.SNOWFLAKE_TOKEN,
+      tokenType: process.env.SNOWFLAKE_TOKEN_TYPE || 'KEYPAIR_JWT',
+      warehouse: process.env.SNOWFLAKE_WAREHOUSE,
+      database: process.env.SNOWFLAKE_DATABASE,
+      schema: process.env.SNOWFLAKE_SCHEMA,
+      role: process.env.SNOWFLAKE_ROLE,
+    });
+    console.log(await connector.listTables());
+    return;
+  }
+
+  if (provider === 'databricks') {
+    connector = createCloudDataConnector('databricks', {
+      host: process.env.DATABRICKS_HOST,
+      token: process.env.DATABRICKS_TOKEN,
+      warehouseId: process.env.DATABRICKS_WAREHOUSE_ID,
+      catalog: process.env.DATABRICKS_CATALOG,
+      schema: process.env.DATABRICKS_SCHEMA,
+    });
+    console.log(await connector.listTables());
+    return;
+  }
+
+  if (provider === 'iceberg') {
+    connector = createCloudDataConnector('iceberg', {
+      baseUrl: process.env.ICEBERG_CATALOG_URL,
+      prefix: process.env.ICEBERG_CATALOG_PREFIX,
+      token: process.env.ICEBERG_CATALOG_TOKEN,
+    });
+    console.log(await connector.listNamespaces());
+    return;
+  }
+
+  throw new Error('Set NEXAMAP_CLOUD_PROVIDER to snowflake, databricks, or iceberg.');
+}
+
+if (require.main === module) {
+  run().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { run };

--- a/server-api/connectors/cloud-data/iceberg-rest-connector.js
+++ b/server-api/connectors/cloud-data/iceberg-rest-connector.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const {
+  assertNonEmpty,
+  normalizeBaseUrl,
+  readJsonResponse,
+} = require('./base-connector');
+
+function encodeNamespace(namespace) {
+  const parts = Array.isArray(namespace) ? namespace : String(namespace || '').split('.');
+  const normalized = parts.map((part) => assertNonEmpty(part, 'namespace part'));
+  return encodeURIComponent(normalized.join('\u001f'));
+}
+
+class IcebergRestConnector {
+  constructor(config = {}) {
+    this.baseUrl = normalizeBaseUrl(config.baseUrl, 'baseUrl');
+    this.prefix = String(config.prefix || '').replace(/^\/+|\/+$/g, '');
+    this.token = config.token || null;
+    this.headersOverride = config.headers || {};
+  }
+
+  headers() {
+    return {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+      ...this.headersOverride,
+    };
+  }
+
+  url(pathname) {
+    const prefix = this.prefix ? `/${this.prefix}` : '';
+    return `${this.baseUrl}/v1${prefix}${pathname}`;
+  }
+
+  async request(pathname, options = {}) {
+    const response = await fetch(this.url(pathname), {
+      ...options,
+      headers: { ...this.headers(), ...(options.headers || {}) },
+    });
+    return readJsonResponse(response, `Iceberg REST request ${pathname}`);
+  }
+
+  async getConfig() {
+    return this.request('/config');
+  }
+
+  async listNamespaces(parent = null) {
+    const query = parent ? `?parent=${encodeNamespace(parent)}` : '';
+    const payload = await this.request(`/namespaces${query}`);
+    return payload.namespaces || [];
+  }
+
+  async loadNamespace(namespace) {
+    return this.request(`/namespaces/${encodeNamespace(namespace)}`);
+  }
+
+  async listTables(namespace) {
+    const payload = await this.request(`/namespaces/${encodeNamespace(namespace)}/tables`);
+    return payload.identifiers || [];
+  }
+
+  async loadTable(namespace, table) {
+    const tableName = encodeURIComponent(assertNonEmpty(table, 'table'));
+    return this.request(`/namespaces/${encodeNamespace(namespace)}/tables/${tableName}`);
+  }
+
+  async tableMetadata(namespace, table) {
+    const loaded = await this.loadTable(namespace, table);
+    return {
+      metadataLocation: loaded['metadata-location'] || loaded.metadataLocation || null,
+      metadata: loaded.metadata || null,
+      config: loaded.config || {},
+    };
+  }
+}
+
+module.exports = { IcebergRestConnector, encodeNamespace };

--- a/server-api/connectors/cloud-data/index.js
+++ b/server-api/connectors/cloud-data/index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { SnowflakeConnector } = require('./snowflake-connector');
+const { DatabricksConnector } = require('./databricks-connector');
+const { IcebergRestConnector } = require('./iceberg-rest-connector');
+
+function createCloudDataConnector(type, config = {}) {
+  switch (String(type || '').toLowerCase()) {
+    case 'snowflake':
+      return new SnowflakeConnector(config);
+    case 'databricks':
+      return new DatabricksConnector(config);
+    case 'iceberg':
+    case 'iceberg-rest':
+      return new IcebergRestConnector(config);
+    default:
+      throw new Error(`Unsupported cloud data connector: ${type}`);
+  }
+}
+
+module.exports = {
+  createCloudDataConnector,
+  SnowflakeConnector,
+  DatabricksConnector,
+  IcebergRestConnector,
+};

--- a/server-api/connectors/cloud-data/snowflake-connector.js
+++ b/server-api/connectors/cloud-data/snowflake-connector.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const {
+  assertNonEmpty,
+  normalizeBaseUrl,
+  readJsonResponse,
+  rowsToGeoJSON,
+} = require('./base-connector');
+
+class SnowflakeConnector {
+  constructor(config = {}) {
+    this.accountUrl = normalizeBaseUrl(config.accountUrl, 'accountUrl');
+    this.token = assertNonEmpty(config.token, 'token');
+    this.database = config.database || null;
+    this.schema = config.schema || null;
+    this.warehouse = config.warehouse || null;
+    this.role = config.role || null;
+    this.tokenType = config.tokenType || 'KEYPAIR_JWT';
+  }
+
+  headers() {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'X-Snowflake-Authorization-Token-Type': this.tokenType,
+    };
+  }
+
+  async execute(sql, options = {}) {
+    const statement = assertNonEmpty(sql, 'sql');
+    const response = await fetch(`${this.accountUrl}/api/v2/statements`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        statement,
+        timeout: options.timeoutSeconds || 60,
+        database: options.database || this.database || undefined,
+        schema: options.schema || this.schema || undefined,
+        warehouse: options.warehouse || this.warehouse || undefined,
+        role: options.role || this.role || undefined,
+      }),
+    });
+    const payload = await readJsonResponse(response, 'Snowflake statement');
+    if (payload.statementHandle && !payload.data) {
+      return this.poll(payload.statementHandle, options);
+    }
+    return this.normalizeResult(payload);
+  }
+
+  async poll(statementHandle, options = {}) {
+    const intervalMs = options.pollIntervalMs || 500;
+    const deadline = Date.now() + (options.timeoutSeconds || 60) * 1000;
+    while (Date.now() < deadline) {
+      const response = await fetch(`${this.accountUrl}/api/v2/statements/${encodeURIComponent(statementHandle)}`, {
+        headers: this.headers(),
+      });
+      if (response.status === 202) {
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        continue;
+      }
+      return this.normalizeResult(await readJsonResponse(response, 'Snowflake statement polling'));
+    }
+    throw new Error('Snowflake statement timed out.');
+  }
+
+  normalizeResult(payload = {}) {
+    const columns = (payload.resultSetMetaData && payload.resultSetMetaData.rowType) || [];
+    const names = columns.map((column) => column.name);
+    const rows = (payload.data || []).map((values) => Object.fromEntries(names.map((name, index) => [name, values[index]])));
+    return {
+      rows,
+      columns,
+      statementHandle: payload.statementHandle || null,
+      rowCount: rows.length,
+    };
+  }
+
+  async listTables() {
+    const result = await this.execute('SHOW TERSE TABLES');
+    return result.rows;
+  }
+
+  async queryGeoJSON(sql, geoOptions = {}, executeOptions = {}) {
+    const result = await this.execute(sql, executeOptions);
+    return rowsToGeoJSON(result.rows, geoOptions);
+  }
+}
+
+module.exports = { SnowflakeConnector };

--- a/tests/cloud-data-connectors.test.js
+++ b/tests/cloud-data-connectors.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  createCloudDataConnector,
+  SnowflakeConnector,
+  DatabricksConnector,
+  IcebergRestConnector,
+} = require('../server-api/connectors/cloud-data');
+const { rowsToGeoJSON } = require('../server-api/connectors/cloud-data/base-connector');
+
+test('rowsToGeoJSON converts coordinates and calculates bbox', () => {
+  const geojson = rowsToGeoJSON([
+    { id: 1, longitude: -96.8, latitude: 32.8, name: 'Dallas' },
+    { id: 2, longitude: -97.3, latitude: 32.7, name: 'Fort Worth' },
+  ], { idColumn: 'id' });
+
+  assert.equal(geojson.features.length, 2);
+  assert.deepEqual(geojson.bbox, [-97.3, 32.7, -96.8, 32.8]);
+  assert.equal(geojson.features[0].geometry.type, 'Point');
+});
+
+test('factory creates supported connectors', () => {
+  assert.ok(createCloudDataConnector('snowflake', {
+    accountUrl: 'https://example.snowflakecomputing.com', token: 'token',
+  }) instanceof SnowflakeConnector);
+  assert.ok(createCloudDataConnector('databricks', {
+    host: 'https://example.cloud.databricks.com', token: 'token', warehouseId: 'wh',
+  }) instanceof DatabricksConnector);
+  assert.ok(createCloudDataConnector('iceberg', {
+    baseUrl: 'https://catalog.example.com',
+  }) instanceof IcebergRestConnector);
+});
+
+test('Snowflake result normalization maps row arrays to objects', () => {
+  const connector = new SnowflakeConnector({
+    accountUrl: 'https://example.snowflakecomputing.com', token: 'token',
+  });
+  const result = connector.normalizeResult({
+    resultSetMetaData: { rowType: [{ name: 'ID' }, { name: 'NAME' }] },
+    data: [[1, 'A']],
+  });
+  assert.deepEqual(result.rows, [{ ID: 1, NAME: 'A' }]);
+});
+
+test('Databricks result normalization maps data_array to objects', () => {
+  const connector = new DatabricksConnector({
+    host: 'https://example.cloud.databricks.com', token: 'token', warehouseId: 'wh',
+  });
+  const result = connector.normalizeResult({
+    statement_id: 's1',
+    manifest: { schema: { columns: [{ name: 'id' }, { name: 'name' }] } },
+    result: { data_array: [[1, 'A']] },
+  });
+  assert.deepEqual(result.rows, [{ id: 1, name: 'A' }]);
+});
+
+test('Iceberg REST namespace encoding uses unit separator', async () => {
+  const originalFetch = global.fetch;
+  let requestedUrl = null;
+  global.fetch = async (url) => {
+    requestedUrl = String(url);
+    return new Response(JSON.stringify({ identifiers: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  try {
+    const connector = new IcebergRestConnector({ baseUrl: 'https://catalog.example.com' });
+    await connector.listTables(['analytics', 'spatial']);
+    assert.match(requestedUrl, /analytics%1Fspatial/);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

Adds a server-side cloud data connector layer for NexaMap with support for:

- Snowflake SQL API
- Databricks Statement Execution API
- Apache Iceberg REST Catalog API
- Shared GeoJSON conversion and bounding-box calculation
- Connector factory and runnable example
- Unit tests and setup documentation

## Implementation details

### Snowflake
- Executes SQL through `/api/v2/statements`
- Supports OAuth or key-pair JWT bearer tokens
- Supports warehouse, database, schema, and role configuration
- Polls asynchronous statements
- Converts query results into row objects and GeoJSON

### Databricks
- Executes SQL through `/api/2.0/sql/statements`
- Supports SQL warehouse, catalog, and schema configuration
- Polls asynchronous statements
- Converts `data_array` results into row objects and GeoJSON

### Iceberg
- Implements REST catalog configuration and discovery
- Lists namespaces and tables
- Loads table metadata and metadata locations
- Supports optional bearer tokens and catalog prefixes

## Testing

Adds `tests/cloud-data-connectors.test.js` covering:

- GeoJSON conversion and BBOX calculation
- Connector factory behavior
- Snowflake result normalization
- Databricks result normalization
- Iceberg namespace encoding

Run with:

```bash
npm test
```

## Notes

Credentials remain server-side and are never exposed to the browser. The implementation uses the built-in Node.js `fetch` API and introduces no new runtime dependencies.